### PR TITLE
refactor: remove setting boolean flag default value to false

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ komando({
 
 ### Run function
 
-- [`run` on Deno Doc](https://doc.deno.land/https://deno.land/x/komando@/mod.js/~/RunFunction)
+- [`run` on Deno Doc](https://doc.deno.land/https://deno.land/x/komando/mod.js/~/RunFunction)
 
 Each command has an optional `run` function to run when the command is
 encountered in the `argv`.
@@ -171,11 +171,11 @@ komando({
 
 ### Misc
 
-- [`groupBy` on Deno Doc](https://doc.deno.land/https://deno.land/x/komando@v0.0.5/mod.js/~/groupBy)
+- [`groupBy` on Deno Doc](https://doc.deno.land/https://deno.land/x/komando/mod.js/~/groupBy)
 
   Commands or flags can be grouped under custom title in the help message. This
   is done by
-  [`groupBy`](https://doc.deno.land/https://deno.land/x/komando@v0.0.5/mod.js/~/groupBy)
+  [`groupBy`](https://doc.deno.land/https://deno.land/x/komando/mod.js/~/groupBy)
   function. It takes a title and an array of commands or a flags object to
   group.
 

--- a/deps.ts
+++ b/deps.ts
@@ -1,1 +1,1 @@
-export * from 'https://deno.land/std@0.125.0/flags/mod.ts';
+export * from 'https://deno.land/std@0.127.0/flags/mod.ts';

--- a/deps_test.ts
+++ b/deps_test.ts
@@ -1,3 +1,3 @@
-export * from 'https://deno.land/std@0.125.0/testing/asserts.ts';
+export * from 'https://deno.land/std@0.127.0/testing/asserts.ts';
 export * from 'https://cdn.skypack.dev/nanospy';
 export * from 'https://deno.land/x/sunappu@v1.0.1/mod.ts';

--- a/mod.js
+++ b/mod.js
@@ -64,7 +64,6 @@ export function defineCommand(options) {
     if (!val.placeholder && typeFn !== Boolean) val.placeholder = key;
     if (typeFn === Boolean) {
       val.placeholder = undefined;
-      val.defaultV = false;
     }
   }
 

--- a/tests/flags_test.ts
+++ b/tests/flags_test.ts
@@ -188,7 +188,7 @@ test('default true flag', () => {
     name,
     flags: { True: { typeFn: Boolean, defaultV: true } },
     run(_, flags) {
-      assert(flags.True)
-    }
-  }, [''])
-})
+      assert(flags.True);
+    },
+  }, ['']);
+});

--- a/tests/flags_test.ts
+++ b/tests/flags_test.ts
@@ -182,3 +182,13 @@ test('no kebab case + no short flag', () => {
     },
   }, ['--open']);
 });
+
+test('default true flag', () => {
+  komando({
+    name,
+    flags: { True: { typeFn: Boolean, defaultV: true } },
+    run(_, flags) {
+      assert(flags.True)
+    }
+  }, [''])
+})


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description

Deno module `flags` will set the default value to `false` unless there is no `defaultV`.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [ ] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [x] Other
